### PR TITLE
dje-opt/threadsafe, plus density output and minor PLT fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ParseHeader
 *.d
 *.par
 FREEZE
+fftw_zeldovich.wisdom

--- a/block_array.cpp
+++ b/block_array.cpp
@@ -179,9 +179,9 @@ public:
                 z = zres+block*zblock;
                 for (yres=0;yres<block;yres++) {
                     // Copy the whole X skewer
-                    Complx *ptr = &(BLK_AYZX(slab,a,yres,z,0));
-                    for(int x = 0; x < ppd; x++)
-                        StoreBlock_tmp[i++] = ptr[x];
+                    memcpy(StoreBlock_tmp+i, &(BLK_AYZX(slab,a,yres,z,0)), ppd*sizeof(Complx));
+                    i+=ppd;
+                    // for(int x = 0; x < ppd; x++)
                         // StoreBlock_tmp[i++] = BLK_AYZX(slab,a,yres,z,x);
                 }
             }
@@ -235,9 +235,9 @@ public:
                     if (y>=ppdhalf) yshift=y+1; else yshift=y;
                     if (yshift==ppd) yshift=ppdhalf;
                     // Put it somewhere; this is about to be overwritten
-                    Complx *ptr = &(BLK_AZYX(slab,a,zres,yshift,0));
-                    for(int x = 0; x < ppd; x++)
-                        ptr[x] = StoreBlock_tmp[i++];
+                    memcpy(&(BLK_AZYX(slab,a,zres,yshift,0)), StoreBlock_tmp+i, ppd*sizeof(Complx));
+                    i+=ppd;
+                    // for(int x = 0; x < ppd; x++)
                         // BLK_AZYX(slab,a,zres,yshift,x) = StoreBlock_tmp[i++];
                 }
         assert(i == ppd*narray*block*block);

--- a/block_array.cpp
+++ b/block_array.cpp
@@ -27,12 +27,14 @@ public:
 
     int numblock, block;
     int64_t ppd;  // Making ppd a 64-bit integer avoids trouble with ppd^3 int32_t overflow
+    int64_t ppdhalf; // ppd/2
     int64_t narray;  // Make int64 to avoid overflow in later calculations
     char TMPDIR[1024];
     int ramdisk;
 
     BlockArray(int _ppd, int _numblock, int _narray, char *_dir, int _ramdisk) {
         ppd = (int64_t) _ppd;
+        ppdhalf = ppd/2;
         numblock = _numblock;
         block = ppd/numblock;
         narray = _narray;
@@ -230,8 +232,8 @@ public:
                     // shift the y frequencies in the reflected half
                     // by one.
                     // FLAW: Assumes ppd is even.
-                    if (y>=ppd/2) yshift=y+1; else yshift=y;
-                    if (yshift==ppd) yshift=ppd/2;
+                    if (y>=ppdhalf) yshift=y+1; else yshift=y;
+                    if (yshift==ppd) yshift=ppdhalf;
                     // Put it somewhere; this is about to be overwritten
                     Complx *ptr = &(BLK_AZYX(slab,a,zres,yshift,0));
                     for(int x = 0; x < ppd; x++)
@@ -307,8 +309,8 @@ public:
             // shift the y frequencies in the reflected half
             // by one.
             // FLAW: Assumes ppd is even.
-            if (y>=ppd/2) yshift=y+1; else yshift=y;
-            if (yshift==ppd) yshift=ppd/2;
+            if (y>=ppdhalf) yshift=y+1; else yshift=y;
+            if (yshift==ppd) yshift=ppdhalf;
             // Put it somewhere; this is about to be overwritten
             bread(IOptr, &(BLK_AZYX(slab,a,zres,yshift,0)),ppd);
         }

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -77,7 +77,7 @@ public:
         seed = 0;    // Legal default
         strcpy(Pk_filename,"");   // Must specify Pk file or power law
         Pk_powerlaw_index = NAN;  // Must specify Pk file or power law
-        strcpy(density_filename,"output.density");  // Legal default
+        strcpy(density_filename,"density%d");  // Legal default
         qonemode = 0; // Legal default
         memset(one_mode, 0, 3*sizeof(int)); // Legal default
         qPLT = 0; // Legal default

--- a/zeldovich.cpp
+++ b/zeldovich.cpp
@@ -446,7 +446,7 @@ void ZeldovichZ(BlockArray& array, Parameters& param, PowerSpectrum& Pk) {
         // Now store it into the primary BlockArray.  
         // Can't openMP an I/O loop.
         storing.Start();
-        #pragma omp parallel for schedule(static)
+        #pragma omp parallel for schedule(dynamic,1)
         for (zblock=0;zblock<array.numblock;zblock++) {
             array.StoreBlock(yblock,zblock,slab);
             array.StoreBlock(array.numblock-1-yblock,zblock,slabHer);
@@ -485,7 +485,7 @@ void ZeldovichXY(BlockArray& array, Parameters& param, FILE *output, FILE *denso
         // Can't openMP an I/O loop.
         loading.Start();
         fprintf(stderr,".");
-        #pragma omp parallel for schedule(static)
+        #pragma omp parallel for schedule(dynamic,1)
         for (yblock=0;yblock<array.numblock;yblock++) {
             array.LoadBlock(yblock, zblock, slab);
         } 

--- a/zeldovich.cpp
+++ b/zeldovich.cpp
@@ -353,6 +353,9 @@ void LoadPlane(BlockArray& array, Parameters& param, PowerSpectrum& Pk,
             // No-op this math if we aren't going to use it
             if(D != 0.){
                 eigenmode e = get_eigenmode(kx, ky, kz, ppd, param.qPLT);
+
+                double rescale = 1.;
+                f = 1.0;
                 if(param.qPLT){
                     // This is f_growth, the logarithmic derivative of the growth factor that scales the velocities
                     // The corrections are sourced from:
@@ -360,19 +363,19 @@ void LoadPlane(BlockArray& array, Parameters& param, PowerSpectrum& Pk,
                     // 2) Addition of a smooth, non-clustering component to the background (<= NOT A PLT EFFECT)
                     // If PLT is turned on, we have to combine the effects here.  If not, we apply f_cluster during output.
                     f = (sqrt(1. + 24*e.val*param.f_cluster) - 1)*.25; // 1/4 instead of 1/6 because v = alpha*u/t0 = 3/2*H*alpha*u
-                } else f = 1.0;
-        
-                double rescale = 1.;
-                if(param.qPLTrescale){
-                    /// double a_NL = 1./(1+param.PLT_target_z);
-                    /// double a0 = 1./(1+param.z_initial);
-                    // First is continuum linear theory growth rate, possibly including f_smooth
-                    // Second is PLT growth rate, also including f_smooth
-                    /// double target_f = (sqrt(1. + 24*param.f_cluster) - 1)/4.;
-                    // double plt_f = (sqrt(1. + 24*e.val*param.f_cluster) - 1)/4.;
-                    double plt_f = f;
-                    rescale = pow(a_NL/a0, target_f - plt_f);
+
+                    if(param.qPLTrescale){
+                        /// double a_NL = 1./(1+param.PLT_target_z);
+                        /// double a0 = 1./(1+param.z_initial);
+                        // First is continuum linear theory growth rate, possibly including f_smooth
+                        // Second is PLT growth rate, also including f_smooth
+                        /// double target_f = (sqrt(1. + 24*param.f_cluster) - 1)/4.;
+                        // double plt_f = (sqrt(1. + 24*e.val*param.f_cluster) - 1)/4.;
+                        double plt_f = f;
+                        rescale = pow(a_NL/a0, target_f - plt_f);
+                    }
                 }
+        
                 F = rescale*I*e.vec[0]*ik2*D;
                 G = rescale*I*e.vec[1]*ik2*D;
                 H = rescale*I*e.vec[2]*ik2*D;

--- a/zeldovich.cpp
+++ b/zeldovich.cpp
@@ -85,20 +85,24 @@ fftw_plan plan1d, plan2d;
 void Setup_FFTW(int n) {
     STimer FFTplanning;
 
-    // For big n, this is slow enough to notice
-    if(n >= 512)
-        fprintf(stderr,"Creating FFTW plans...");
-
     FFTplanning.Start();
+    char wisdom_file[1024];
+    int wisdom_exists;
+    sprintf(wisdom_file, "fftw_zeldovich.wisdom"); 
+        // TODO: Where to put this file?  param.output_dir?  Or in the repository?
+        // Currently in the repository
+    wisdom_exists = fftw_import_wisdom_from_filename(wisdom_file);
+    fprintf(stderr,"FFTW Wisdom import from file \"%s\" returned %d (%s).\n", wisdom_file, wisdom_exists, wisdom_exists == 1 ? "success" : "failure");
+
     fftw_complex *p;
     p = new fftw_complex[n*n];
     plan1d = fftw_plan_dft_1d(n, p, p, +1, FFTW_PATIENT);
     plan2d = fftw_plan_dft_2d(n, n, p, p, +1, FFTW_PATIENT);
     delete []p;
+    int ret = fftw_export_wisdom_to_filename(wisdom_file);
+    fprintf(stderr,"FFTW Wisdom export to file \"%s\" returned %d.\n", wisdom_file, ret);
     FFTplanning.Stop();
-
-    if(n >= 512)
-        fprintf(stderr," done in %f sec.\n", FFTplanning.Elapsed());
+    fprintf(stderr,"Creating FFTW plans done in %f sec.\n", FFTplanning.Elapsed());
 }
 
 // TODO: This handling of the memory allocation required for plans 

--- a/zeldovich.cpp
+++ b/zeldovich.cpp
@@ -437,7 +437,7 @@ void ZeldovichZ(BlockArray& array, Parameters& param, PowerSpectrum& Pk) {
         // Load the deltas and do the FFTs for each pair of planes
         fprintf(stderr,".."); fflush(stderr);
         compute_planes.Start();
-        #pragma omp parallel for schedule(static)
+        #pragma omp parallel for schedule(dynamic,1)
         for (int yres=0;yres<array.block;yres++) {     
             LoadPlane(array,param,Pk,yblock,yres,slab,slabHer);
         }
@@ -505,7 +505,7 @@ void ZeldovichXY(BlockArray& array, Parameters& param, FILE *output, FILE *denso
 
         // Now we want to do the Y & X inverse FFT.
         for (a=0;a<array.narray;a++) {
-            #pragma omp parallel for schedule(static)
+            #pragma omp parallel for schedule(dynamic,1)
             for (int zres=0;zres<array.block;zres++) {
                 Inverse2dFFT(&(AZYX(slab,a,zres,0,0)),array.ppd);
             }

--- a/zeldovich.cpp
+++ b/zeldovich.cpp
@@ -495,7 +495,7 @@ void ZeldovichZ(BlockArray& array, Parameters& param, PowerSpectrum& Pk) {
 #define AZYX(_slab,_a,_z,_y,_x) _slab[(int64_t)(_x)+array.ppd*((_y)+array.ppd*((_a)+array.narray*(_z)))]
 
 
-void ZeldovichXY(BlockArray& array, Parameters& param, FILE *output, FILE *densoutput) {
+void ZeldovichXY(BlockArray& array, Parameters& param, FILE *output) {
     // Do the Y & X inverse FFT and output the results.
     // Do this one Z slab at a time; try to load the data in order.
     // Try to write the output file in z order
@@ -550,7 +550,7 @@ void ZeldovichXY(BlockArray& array, Parameters& param, FILE *output, FILE *denso
             int z = zres+array.block*zblock;
             if (param.qoneslab<0||z==param.qoneslab) {
                 // We have the option to output only one z slab.
-                WriteParticlesSlab(output,densoutput,z,
+                WriteParticlesSlab(output,z,
                 &(AZYX(slab,0,zres,0,0)), &(AZYX(slab,1,zres,0,0)),
                 &(AZYX(slab,2,zres,0,0)), &(AZYX(slab,3,zres,0,0)),
                 array, param);
@@ -611,7 +611,7 @@ int main(int argc, char *argv[]) {
     STimer totaltime;
     totaltime.Start();
     
-    FILE *output, *densoutput;
+    FILE *output;
     double memory;
     density_variance = 0.0;
     Parameters param(argv[1]);
@@ -647,11 +647,6 @@ int main(int argc, char *argv[]) {
     fprintf(stderr,"Block size: %5.3f GiB\n", memory/param.numblock/param.numblock);
 #endif
 
-    if (param.qdensity>0) {
-        densoutput = fopen(param.density_filename,"w");
-        assert(densoutput!=NULL);
-    } else densoutput = NULL;
-
     if(param.qPLT){
         load_eigmodes(param);
     }
@@ -678,7 +673,7 @@ int main(int argc, char *argv[]) {
     totaltime.Start();
 
     output = 0; // Current implementation doesn't use user-provided output
-    ZeldovichXY(array, param, output, densoutput);
+    ZeldovichXY(array, param, output);
     totaltime.Stop();
     fprintf(stderr,"Time so far: %f seconds\n", totaltime.Elapsed());
     totaltime.Start();

--- a/zeldovich.cpp
+++ b/zeldovich.cpp
@@ -660,7 +660,7 @@ int main(int argc, char *argv[]) {
         fprintf(stderr,"Using k_cutoff = %f (effective ppd = %d)\n", param.k_cutoff, (int)(param.ppd/param.k_cutoff+.5));
     }
 
-    BlockArray array(param.ppd,param.numblock,narray,param.output_dir,param.ramdisk);
+    BlockArray array(param.ppd,param.numblock,narray,param.output_dir,param.ramdisk, 1);
 
     totaltime.Stop();
     fprintf(stderr,"Preamble took %f seconds\n", totaltime.Elapsed());

--- a/zeldovich.cpp
+++ b/zeldovich.cpp
@@ -95,11 +95,13 @@ void Setup_FFTW(int n) {
     fprintf(stderr,"FFTW Wisdom import from file \"%s\" returned %d (%s).\n", wisdom_file, wisdom_exists, wisdom_exists == 1 ? "success" : "failure");
 
     fftw_complex *p;
-    p = new fftw_complex[n*n];
+    // p = new fftw_complex[n*n];
+    int ret = posix_memalign((void **)&p, 4096, n*n*sizeof(Complx));
     plan1d = fftw_plan_dft_1d(n, p, p, +1, FFTW_PATIENT);
     plan2d = fftw_plan_dft_2d(n, n, p, p, +1, FFTW_PATIENT);
-    delete []p;
-    int ret = fftw_export_wisdom_to_filename(wisdom_file);
+    free(p);
+    // delete []p;
+    ret = fftw_export_wisdom_to_filename(wisdom_file);
     fprintf(stderr,"FFTW Wisdom export to file \"%s\" returned %d.\n", wisdom_file, ret);
     FFTplanning.Stop();
     fprintf(stderr,"Creating FFTW plans done in %f sec.\n", FFTplanning.Elapsed());
@@ -129,14 +131,18 @@ void InverseFFT_Yonly(Complx *p, int n) {
     // our 3-d problem!
     Complx *tmp;
     int j,k;
-    tmp = new Complx[n];
+    int ret = posix_memalign((void **)&tmp, 4096, n*sizeof(Complx));
+    assert(ret==0);
+
+    // tmp = new Complx[n];
     for (j=0;j<n;j++) {
         // We will load one row at a time
         for (k=0;k<n;k++) tmp[k] = p[k*n+j];
         Inverse1dFFT(tmp, n);
         for (k=0;k<n;k++) p[k*n+j] = tmp[k];
     }
-    delete []tmp;
+    free(tmp);
+    //delete []tmp;
 }
 
 //================================================================

--- a/zeldovich.cpp
+++ b/zeldovich.cpp
@@ -427,6 +427,7 @@ void ZeldovichZ(BlockArray& array, Parameters& param, PowerSpectrum& Pk) {
 
         // Now store it into the primary BlockArray.  
         // Can't openMP an I/O loop.
+        #pragma omp parallel for schedule(static)
         for (zblock=0;zblock<array.numblock;zblock++) {
             array.StoreBlock(yblock,zblock,slab);
             array.StoreBlock(array.numblock-1-yblock,zblock,slabHer);
@@ -461,6 +462,7 @@ void ZeldovichXY(BlockArray& array, Parameters& param, FILE *output, FILE *denso
         // Load the slab back in.  
         // Can't openMP an I/O loop.
         fprintf(stderr,".");
+        #pragma omp parallel for schedule(static)
         for (yblock=0;yblock<array.numblock;yblock++) {
             array.LoadBlock(yblock, zblock, slab);
         } 
@@ -603,6 +605,7 @@ int main(int argc, char *argv[]) {
     Setup_FFTW(param.ppd);
 
     ZeldovichZ(array, param, Pk);
+    fprintf(stderr,"Wrote %d files\n", array.files_written);
 
     output = 0; // Current implementation doesn't use user-provided output
     ZeldovichXY(array, param, output, densoutput);


### PR DESCRIPTION
This merges the dje-opt and dje-threadsafe branches into master; we've tested those pretty thoroughly.  And this includes the dens-out branch, which resurrects the `ZD_qdensity` parameter.  There's also a small fix to automatically turn off PLT rescaling if PLT eigenmodes are not in use.