### PR TITLE
Allow splitting zeldovich Z and XY loops into two executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 zeldovich
+zeldovich_part1
+zeldovich_part2
 rng_test
 ParseHeader
 !ParseHeader/

--- a/Makefile
+++ b/Makefile
@@ -25,24 +25,32 @@ CPPFLAGS += $(THREAD_CPPFLAGS) $(PARSEHEADER_CPPFLAGS) $(GSL_CPPFLAGS) -DDISK
 
 LIBS += $(PARSEHEADER_LIBS) -lfftw3 $(GSL_LIBS) -lstdc++
 
+TARGETS := zeldovich zeldovich_part1 zeldovich_part2
+OBJ := $(TARGETS:%=%.o)
+
 all: zeldovich 
 
-zeldovich: zeldovich.o | ParseHeader
+$(TARGETS) : % : %.o | ParseHeader
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $< -o $@ $(LIBS)
 
-zeldovich.o: zeldovich.cpp
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -MMD -c $<
+$(OBJ): % : zeldovich.cpp
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -MMD -c $< -o $@
+
+twopart: zeldovich_part1 zeldovich_part2
+
+zeldovich_part1: CPPFLAGS += -DPART1
+zeldovich_part2: CPPFLAGS += -DPART2
 
 -include zeldovich.d
 
-.PHONY: all clean distclean default
+.PHONY: all clean distclean default twopart
 clean:
 	$(MAKE) -C ParseHeader $@
-	$(RM) *.o *.gch *~
+	$(RM) $(OBJ) *.gch *~
 
 distclean: clean
 	$(MAKE) -C ParseHeader $@
-	$(RM) zeldovich *.d
+	$(RM) $(TARGETS) *.d
 
 ifndef HAVE_COMMON_MK
 ParseHeader: ParseHeader/libparseheader.a

--- a/output.cpp
+++ b/output.cpp
@@ -185,11 +185,13 @@ BlockArray& array, Parameters& param) {
 int CleanDirectory(const char *path);
 int CreateDirectories(const char *path);
 
-// Returns GiB size of allocated buffer
-double InitOutput(Parameters &param){
+void SetupOutputDir(Parameters &param){
     CleanDirectory(param.output_dir);
     CreateDirectories(param.output_dir);
+}
 
+// Returns GiB size of allocated buffer
+double InitOutputBuffers(Parameters &param){
     if(strcmp(param.ICFormat, "RVdoubleZel") == 0){
         param_icformat = OUTPUT_RVDOUBLEZEL;
         output_tmp = new RVdoubleZelParticle[param.ppd*param.ppd];
@@ -211,7 +213,7 @@ double InitOutput(Parameters &param){
     if(param.qdensity){
         char fn[256];
         sprintf(fn, param.density_filename, param.ppd);
-        char path[1080];
+        char path[1300];
         sprintf(path, "%s/%s", param.output_dir, fn);
         densfp = fopen(path, "wb");
         assert(densfp != NULL);


### PR DESCRIPTION
Run `make twopart` to build `zeldovich_part1` and `zeldovich_part2`, which can be run in succession to produce the same result as `zeldovich`.  Generally only useful when queue time limits force you to divide the work into two jobs.

Tested with a large IC job; results match to binary precision.