### PR TITLE
Add support for f_NL

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ overall memory usage.
 We provide a precompted set of 128<sup>3</sup> numerical eigenmodes with this code.
 The code does linear interpolation if a finer FFT mesh is being used.
 
+## Primordial Non-Gaussianity
+This code supports the generation of initial conditions with local primordial
+non-Gaussianity ($f_NL$). The parameters that affect f_NL are:
+* `ZD_f_NL`: the ampltiude of the non-Gaussianity
+* `ZD_n_s`: for inferring the transfer function
+* `Omega_M`: for computing the Bardeen potential from the density
+* `InitialRedshift`: for computing the EdS growth factor
 
 ## Parameter file options
 `ZD_Seed`: *integer*  

--- a/README.md
+++ b/README.md
@@ -199,11 +199,28 @@ The code does linear interpolation if a finer FFT mesh is being used.
 
 ## Primordial Non-Gaussianity
 This code supports the generation of initial conditions with local primordial
-non-Gaussianity ($f_NL$). The parameters that affect f_NL are:
+non-Gaussianity ($f_\mathrm{NL}$). The parameters that affect f_NL are:
 * `ZD_f_NL`: the ampltiude of the non-Gaussianity
 * `ZD_n_s`: for inferring the transfer function
 * `Omega_M`: for computing the Bardeen potential from the density
 * `InitialRedshift`: for computing the EdS growth factor
+
+f_NL is implemented by generating the density modes as a Gaussian random field
+as normal, then converting them to primordial potential $\Phi_g$ by dividing out the
+$M(k,a)$ factor from 1108.5512, eq. 50. $\Phi_g$ is then packed into a `BlockArray` and
+undergoes a backward FFT to get $\Phi_g(x)$ (as the code only supports C->C transforms,
+this does double the necessary work, but is otherwise harmless). In config space,
+we apply local PNG: $\Phi(x) = \Phi_g(x) + f_\mathrm{NL} \Phi_g(x) \Phi_g(x)$. We then
+execute a forward FFT and feed $\Phi$ back into the density mode generation routine,
+where we multiply by $M$ to recover $\delta(k)$.  The rest of the code proceeds as normal.
+
+The $M$ factor is:
+```math
+M(k,a) = \frac{2 D(a) c^2 T(k) k^2}{3 \Omega_M H_0^2}.
+```
+The transfer function $T(k)$ is inferred by this code from the ratio of the primordial power spectrum spectral index $P = k^{n_s}$ to the input power spectrum, where $n_s$ is given by `ZD_n_s`, and assuming $T(k) = 1$ on large scales (smallest $k$ of the input power spectrum). If this assumption needs to be relaxed, one can modify this code to accept a file with an input transfer function.
+
+Note that because f_NL adds an extra array, it increases peak memory/disk usage.
 
 ## Parameter file options
 `ZD_Seed`: *integer*  
@@ -374,7 +391,7 @@ This will generate files of the name `zeldovich.%d.%d`, which should be automati
 deleted after the code has finished.
 
 `InitialRedshift`: *double*  
-The output redshift.  This is **only used for determining rescaling amplitude**; i.e. this option has no effect if `ZD_qPLT_rescale` is not set.  This code does not compute growth functions; `ZD_Pk_sigma` controls the power spectrum normalization.
+The output redshift.  This is **only used for determining rescaling amplitude, and for f_NL**; i.e. this option has no effect if neither `ZD_qPLT_rescale` nor `ZD_f_NL` are set.  This code does not compute growth functions; `ZD_Pk_sigma` controls the power spectrum normalization.
 
 `ICFormat`: *string*  
 Valid options are: `RVZel`, `RVdoubleZel`, or `Zeldovich`.

--- a/example.par
+++ b/example.par
@@ -21,3 +21,4 @@ ZD_qPLT = 1
 ZD_qPLT_rescale = 0
 ZD_qPk_fix_to_mean = 0
 ZD_Version = 2
+ZD_f_NL = 0

--- a/include/block_array.h
+++ b/include/block_array.h
@@ -80,15 +80,17 @@ private:
 public:
     void StoreBlock(int yblock, int zblock, Complx *slab);
     void LoadBlock(int yblock, int zblock, Complx *slab);
+    void StoreBlockForward(int yblock, int zblock, Complx *slab);
+    void LoadBlockForward(int yblock, int zblock, Complx *slab);
 
 #else   // not DISK
     // These routines are for reading in and out of a big array in memory
 
-private: 
-    Complx *IOptr;
 public:
     void StoreBlock(int yblock, int zblock, Complx *slab);
     void LoadBlock(int yblock, int zblock, Complx *slab);
+    void StoreBlockForward(int yblock, int zblock, Complx *slab);
+    void LoadBlockForward(int yblock, int zblock, Complx *slab);
 
 private:
 

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -45,6 +45,8 @@ public:
     char PLT_filename[1024]; // file containing PLT eigenmodes
     int qPLTrescale; // If non-zero, rescale the initial amplitudes to match continuum linear theory at PLT_target_z
     double PLT_target_z; // The target redshift for the PLT rescaling
+
+    double f_NL;  // phi^2(x) prefactor for local primordial non-Gaussianity
     
     char ICFormat[1024]; // Abacus's expected input format (i.e. our output format)
     

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -47,6 +47,8 @@ public:
     double PLT_target_z; // The target redshift for the PLT rescaling
 
     double f_NL;  // phi^2(x) prefactor for local primordial non-Gaussianity
+    double n_s;  // Spectral index of the primordial power (only used for f_NL)
+    double Omega_M;  // Omega_M at z=0 (only used for f_NL)
     
     char ICFormat[1024]; // Abacus's expected input format (i.e. our output format)
     

--- a/include/power_spectrum.h
+++ b/include/power_spectrum.h
@@ -21,7 +21,10 @@ public:
     double Pk_smooth2;   // param.Pk_smooth squared
     double Rnorm;
     double kmax;  // max k in the input PS
+    double kmin;  // min (non-zero) k in the input PS
     int block;
+    double primordial_norm;
+    double n_s;
 
     gsl_rng **v1rng;  // The random number generators for the deprecated ZD_Version=1
     pcg64 *v2rng;  // The random number generators for version 2 (current version)
@@ -39,6 +42,8 @@ public:
     void Normalize(Parameters& param);
 
     double power(double wavenumber);
+    double primordial_power(double wavenumber);
+    double infer_Tk(double wavenumber);
 
     template <int Ver>
     double one_rand(int64_t i);

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('zeldovich-PLT',
         'cpp',
         default_options : ['cpp_std=c++11', 'debug=true', 'optimization=3'],
+        # default_options : ['cpp_std=c++11', 'debug=true', 'b_sanitize=address'],
         )
 add_global_arguments('-march=native', language : 'cpp')
 

--- a/src/block_array.cpp
+++ b/src/block_array.cpp
@@ -410,7 +410,7 @@ void BlockArray::LoadBlockForward(int yblock, int zblock, Complx *slab) {
     thisrtimer.Start();
 
     unsigned int a;
-    int yres,zres,yshift,z;
+    int yres,zres,z;
     Complx *IOptr = bopen(yblock,zblock,"r");
     for (a=0;a<narray;a++)
     for (yres=0;yres<block;yres++)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -39,7 +39,6 @@ BlockArray& array, Parameters& param) {
     thisouttimer.Start();
     double thisdensity_variance=0.0;
     int just_density = param.qdensity == 2;  // no displacements
-    int have_dens = just_density || param.qPLT;
 
     // Write out one slab of particles
     int x,y;
@@ -77,9 +76,7 @@ BlockArray& array, Parameters& param) {
             //       pos[0] = x*param.separation+imag(YX(slab1,y,x))*norm;
             //       pos[1] = y*param.separation+real(YX(slab2,y,x))*norm;
             //       pos[2] = z*param.separation+imag(YX(slab2,y,x))*norm;
-            if(have_dens){
-                dens = real(YX(slab1,y,x))*densitynorm;
-            }
+            dens = real(YX(slab1,y,x))*densitynorm;
             if(!just_density){
                 pos[0] = imag(YX(slab1,y,x))*norm;
                 pos[1] = real(YX(slab2,y,x))*norm;
@@ -146,11 +143,9 @@ BlockArray& array, Parameters& param) {
                 }
             }
             
-            if(have_dens){
-                if(param.qdensity)
-                    densoutput_tmp[i] = dens;  // casts to float
-                thisdensity_variance += dens*dens;
-            }
+            if(param.qdensity)
+                densoutput_tmp[i] = dens;  // casts to float
+            thisdensity_variance += dens*dens;
 
             // cic->add_cic(param.boxsize,pos);
 
@@ -171,7 +166,7 @@ BlockArray& array, Parameters& param) {
     int64_t totsize = array.ppd*array.ppd*sizeof_outputtype;
 
     // Append to the density file
-    if (param.qdensity && have_dens) {
+    if (param.qdensity) {
         // This whole function is called in z order presently, so we just append density planes to the same file
         fwrite(densoutput_tmp, sizeof(*densoutput_tmp)*array.ppd*array.ppd, 1, densfp);
         totsize += sizeof(*densoutput_tmp)*array.ppd*array.ppd;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -39,13 +39,12 @@ BlockArray& array, Parameters& param) {
     thisouttimer.Start();
     double thisdensity_variance=0.0;
     int just_density = param.qdensity == 2;  // no displacements
-    int have_dens = just_density || param.qPLT || param.f_NL == 0.;
+    int have_dens = just_density || param.qPLT;
 
     // Write out one slab of particles
     int x,y;
     double pos[3], vel[3], dens;
     double norm, densitynorm, vnorm;
-    double fnl_factor = 1.;  // (1 + 2*f_NL*Phi)
     // We also need to fix the normalizations, which come from many places:
     // 1) We used ik/k^2 to apply the velocities.
     //    We did correctly divide by param.fundamental when doing this.
@@ -82,21 +81,17 @@ BlockArray& array, Parameters& param) {
                 dens = real(YX(slab1,y,x))*densitynorm;
             }
             if(!just_density){
-                if(param.f_NL != 0.){
-                    double phi = param.qPLT ? real(YX(slab3,y,x)) : real(YX(slab1,y,x));
-                    fnl_factor = 1 + 2*param.f_NL*phi;
-                }
-                pos[0] = imag(YX(slab1,y,x))*fnl_factor*norm;
-                pos[1] = real(YX(slab2,y,x))*fnl_factor*norm;
-                pos[2] = imag(YX(slab2,y,x))*fnl_factor*norm;
+                pos[0] = imag(YX(slab1,y,x))*norm;
+                pos[1] = real(YX(slab2,y,x))*norm;
+                pos[2] = imag(YX(slab2,y,x))*norm;
                 if(param.qPLT){
-                    vel[0] = imag(YX(slab3,y,x))*fnl_factor*vnorm;
-                    vel[1] = real(YX(slab4,y,x))*fnl_factor*vnorm;
-                    vel[2] = imag(YX(slab4,y,x))*fnl_factor*vnorm;
+                    vel[0] = imag(YX(slab3,y,x))*vnorm;
+                    vel[1] = real(YX(slab4,y,x))*vnorm;
+                    vel[2] = imag(YX(slab4,y,x))*vnorm;
                 } else {
-                    vel[0] = imag(YX(slab1,y,x))*fnl_factor*vnorm;
-                    vel[1] = real(YX(slab2,y,x))*fnl_factor*vnorm;
-                    vel[2] = imag(YX(slab2,y,x))*fnl_factor*vnorm;
+                    vel[0] = imag(YX(slab1,y,x))*vnorm;
+                    vel[1] = real(YX(slab2,y,x))*vnorm;
+                    vel[2] = imag(YX(slab2,y,x))*vnorm;
                     //vel[0] = 0; vel[1] = 0;vel[2] = 0;
                 }
                 //            WRAP(pos[0]);

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -40,6 +40,8 @@ Parameters::Parameters(char *inputfile): Header() {
     AllowDirectIO = 0;  // Legal default for most cases
     version = -1;  // All new ICs should use verison 2 (default), but version 1 is available for backwards compatibility
     CornerModes = 0;  // Legal default (no corner modes)
+    n_s = 1;  // Legal default (only used for f_NL)
+    Omega_M = 1.0;  // Legal default (only used for f_NL)
     
     // Read the paramater file values
     register_vars();
@@ -86,6 +88,8 @@ void Parameters::register_vars(void) {
     installscalar("ZD_PLT_target_z",PLT_target_z,DONT_CARE);
     installscalar("ZD_k_cutoff",k_cutoff,DONT_CARE);
     installscalar("ZD_f_NL",f_NL,DONT_CARE);
+    installscalar("ZD_n_s",n_s,DONT_CARE);
+    installscalar("Omega_M",Omega_M,DONT_CARE);
     installscalar("ICFormat",ICFormat,MUST_DEFINE);
     installscalar("AllowDirectIO",AllowDirectIO,DONT_CARE);
     installscalar("ZD_Version",version,DONT_CARE);
@@ -165,6 +169,17 @@ int Parameters::setup() {
     
     if(qonemode)
         fprintf(stderr,"one_mode: %d, %d, %d\n",one_mode[0],one_mode[1],one_mode[2]);
+
+    if(f_NL != 0.){
+        fprintf(stderr,
+            "Generating local primordial non-Gaussianity, with parameters:\n"
+            " - ZD_f_NL = %g\n"
+            " - ZD_n_s = %g\n"
+            " - Omega_M = %g\n"
+            " - InitialRedshift = %g\n",
+            f_NL, n_s, Omega_M, z_initial
+            );
+    }
     
     return 0;
 }

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -34,6 +34,7 @@ Parameters::Parameters(char *inputfile): Header() {
     strcpy(PLT_filename,""); // Legal default
     qPLTrescale = 0; // Legal default
     PLT_target_z = 0.; // Legal default, probably don't want!
+    f_NL = 0.;  // Legal default; no primordial non-Gaussianity
     k_cutoff = 1.; // Legal default (corresponds to k_nyquist)
     strcpy(ICFormat,""); // Illegal default
     AllowDirectIO = 0;  // Legal default for most cases
@@ -84,6 +85,7 @@ void Parameters::register_vars(void) {
     installscalar("ZD_qPLT_rescale",qPLTrescale,DONT_CARE);
     installscalar("ZD_PLT_target_z",PLT_target_z,DONT_CARE);
     installscalar("ZD_k_cutoff",k_cutoff,DONT_CARE);
+    installscalar("ZD_f_NL",f_NL,DONT_CARE);
     installscalar("ICFormat",ICFormat,MUST_DEFINE);
     installscalar("AllowDirectIO",AllowDirectIO,DONT_CARE);
     installscalar("ZD_Version",version,DONT_CARE);

--- a/src/power_spectrum.cpp
+++ b/src/power_spectrum.cpp
@@ -242,6 +242,8 @@ double PowerSpectrum::infer_Tk(double wavenumber){
     // We call this "infer_Tk" to make it clear that we're inferring the value
     // by assuming T(k) = 1 on large scales, rather than reading a file with
     // the transfer function.
+    if (wavenumber<=0.0)
+        return 1.0;
     return sqrt(power(wavenumber) / primordial_power(wavenumber));
 }
 


### PR DESCRIPTION
This is an attempt at adding support for local primordial non-Gaussianity of the type:
```math
\Phi = \Phi_\rm{G} + f_\rm{NL}\Phi_\rm{G}^2
```

The implementation follows from @deisenstein's observation that the displacements, $\vec{q}$, can be computed using the chain rule as
```math
\begin{align}
\vec{q} &= \nabla \Phi \\
&= (1 + 2 f_\rm{NL}\Phi_\rm{G})\nabla\Phi_\rm{G},
\end{align}
```
which is just a prefactor times the Gaussian displacements.  So all we need is $\Phi_\rm{G}$, which we can get for "free" since we have an unused slot in our complex iFFTs!

The new parameter to the code is called `ZD_f_NL`.  It looks like it works, but I have low confidence that I got the units/amplitude right.

In particular, $1 + 2 f_\rm{NL}\Phi$ needs to be dimensionless, but since $\vec{q} = \nabla \Phi$, the potential naively has units of length^2.  I *think* this means that instead of $\tilde\Phi = \tilde\delta/k^2$, we should form the potential for the f_NL prefactor as $\tilde\Phi = \tilde\delta/(k/k_F)^2$... but I'm not certain.  Maybe there should be an Lbox^-2 factor in config space rather than a k_F^2 factor in Fourier space? Or something else...?

@deisenstein, any thoughts here would be much appreciated.

In any case, here's what f_NL = 100 looks like in a 2 Gpc/h LCDM box. I think it looks potentially okay, but suggestions on how to test this are welcome. I may ask for volunteers in DESI to run 2LPTic or something and compare the results.

![image](https://github.com/abacusorg/zeldovich-PLT/assets/5640139/73baaa6c-20a3-4d77-b9c0-dd90cea6d091)
